### PR TITLE
doc: Update README.md to reflect switch to pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,14 @@ Clone repository
 git clone https://github.com/ebrithiljonas/fittrackee-uploader.git
 ```
 
-Install dependencies
+Install the package and all dependencies
 
 ```sh
 cd fittrackee-uploader
-pip install -r requirements.txt
+pip install .
 ```
+
+If you wish to work on or modify the code base then include the `-e` flag.
 
 Run application
 


### PR DESCRIPTION
Closes #14

With the switch to `pyproject.toml` for configuring the package the `requirements.txt` was removed. I forgot to update the `README.md` to reflect how to install the package and its requirement. This commit corrects that.